### PR TITLE
Fix data length issue

### DIFF
--- a/helpers/data.js
+++ b/helpers/data.js
@@ -2,11 +2,7 @@ const clone = require("clone");
 const array2d = require("array2d");
 
 function getDataWithoutHeaderRow(data) {
-  // todo: understand why sometimes length is 27 and sometimes 26
-  if (data.length === 27) {
-    return data.slice(1);
-  }
-  return data;
+  return data.slice(1);
 }
 
 function getUniqueCategories(data) {

--- a/routes/rendering-info/web.js
+++ b/routes/rendering-info/web.js
@@ -66,6 +66,11 @@ module.exports = {
   handler: async function (request, h) {
     try {
       const item = request.payload.item;
+
+      // we need a copy of the unchanged item to hand it over to client side script
+      // in case no width is given we call rendering info route again with this item
+      // and client side measured width of container
+      const originalItem = { ...item };
       const toolRuntimeConfig = request.payload.toolRuntimeConfig;
 
       // since we do not need header row for further processing we remove it here first
@@ -152,7 +157,7 @@ module.exports = {
               requestId: context.id,
               choroplethType: context.item.options.choroplethType,
               width: context.contentWidth,
-              item: item,
+              item: originalItem,
               toolRuntimeConfig: toolRuntimeConfig,
             })})`,
           },


### PR DESCRIPTION
* removes hot fix
* adds original copy of item which is handed over to client side script: In case there is no width given in request, the client side script will call renderingInfo route again with a measured width of the container, therefore we need the unchanged version of the item.

can be tested locally by starting Q cli server and check fixture data