### PR TITLE
Get enum values of entityType using dynamicSchema

### DIFF
--- a/resources/schema.json
+++ b/resources/schema.json
@@ -43,9 +43,14 @@
       "title": "Geo-Code",
       "type": "string",
       "default": "name",
-      "enum": ["bfsNumber", "name", "code"],
       "Q:options": {
-        "enum_titles": ["BfS Nummer", "Name", "Abkürzung"]
+        "dynamicSchema": {
+          "type": "ToolEndpoint",
+          "config": {
+            "endpoint": "dynamic-schema/entityType",
+            "fields": ["baseMap"]
+          }
+        }
       }
     },
     "data": {

--- a/routes/dynamic-schema.js
+++ b/routes/dynamic-schema.js
@@ -144,11 +144,7 @@ function getCantons(baseMapEntityCollection, entityType) {
   return undefined;
 }
 
-async function getPredefinedContent(
-  baseMapEntityCollection,
-  baseMap,
-  entityType
-) {
+function getPredefinedContent(baseMapEntityCollection, baseMap, entityType) {
   if (baseMap === "hexagonCHCantons") {
     const predefinedContent = getCantons(baseMapEntityCollection, entityType);
     return {
@@ -173,19 +169,17 @@ module.exports = {
   },
   handler: async function (request, h) {
     const item = request.payload.item;
+    const optionName = request.params.optionName;
 
-    // TODO: add entityType as dynamic schema instead of fixed enum
-    // in prep for other base maps with other entityTypes
-
-    if (request.params.optionName === "scale") {
+    if (optionName === "scale") {
       return getScaleEnumWithTitles(item.options.numericalOptions);
     }
 
-    if (request.params.optionName === "colorScheme") {
+    if (optionName === "colorScheme") {
       return getColorSchemeEnumWithTitles(item.options.numericalOptions.scale);
     }
 
-    if (request.params.optionName === "colorOverwrites") {
+    if (optionName === "colorOverwrites") {
       if (item.options.choroplethType === "numerical") {
         return getMaxItemsNumerical(item.options.numericalOptions);
       } else {
@@ -193,7 +187,7 @@ module.exports = {
       }
     }
 
-    if (request.params.optionName === "colorOverwritesItem") {
+    if (optionName === "colorOverwritesItem") {
       if (item.options.choroplethType === "numerical") {
         return getColorOverwriteEnumAndTitlesNumerical(
           item.options.numericalOptions
@@ -203,7 +197,7 @@ module.exports = {
       }
     }
 
-    if (request.params.optionName === "predefinedContent") {
+    if (optionName === "predefinedContent") {
       const baseMapEntityCollectionResponse = await request.server.inject({
         method: "GET",
         url: `/entityCollection/${item.baseMap}`,
@@ -217,6 +211,19 @@ module.exports = {
           item.entityType
         );
       }
+    }
+
+    if (optionName === "entityType") {
+      if (item.baseMap === "hexagonCHCantons") {
+        return {
+          enum: ["bfsNumber", "name", "code"],
+          "Q:options": {
+            enum_titles: ["BfS Nummer", "Name", "Abkürzung"],
+          },
+        };
+      }
+
+      return {};
     }
 
     return Boom.badRequest();


### PR DESCRIPTION
This PR get the enum values for the `entityType` property using dynamicSchema. The default enum value can currently not be set through a dynamicSchema as `predefinedContent` depends on it. This would allow to configure the default `entityType` based on the `baseMap`. I think its fine though. I guess every `baseMap` will have at least a name `entityType`. So its save to take this as default `entityType` for all baseMaps.

This branch is deployed on staging: https://q.st-test.nzz.ch/item/e9046b127bd99afc9cd208b94d0971d3