### PR TITLE
feat: add support for tabular numerals

### DIFF
--- a/views/ChoroplethLegend.svelte
+++ b/views/ChoroplethLegend.svelte
@@ -137,10 +137,10 @@
         class="q-choropleth-legend-container"
         style="width: {widthConfig.legend}%">
         <div class="q-choropleth-legend-value-container">
-          <span class="q-choropleth-legend-value-container--minVal s-font-note">
+          <span class="q-choropleth-legend-value-container--minVal s-font-note s-font-note--tabularnums">
             {getFormattedValueForBuckets(formattingOptions, legendData.minValue)}
           </span>
-          <span class="q-choropleth-legend-value-container--maxVal s-font-note">
+          <span class="q-choropleth-legend-value-container--maxVal s-font-note s-font-note--tabularnums">
             {getFormattedValueForBuckets(formattingOptions, legendData.maxValue)}
           </span>
         </div>
@@ -182,7 +182,7 @@
         </div>
         {#if labelLegend.label !== 'noLabel'}
           <div
-            class="q-choropleth-legend-marker s-font-note"
+            class="q-choropleth-legend-marker s-font-note s-font-note--tabularnums"
             style={getDescriptionAlignment(labelLegend)}>
             {labelLegend.label}: {getFormattedValue(formattingOptions, labelLegend.value)}
           </div>
@@ -205,7 +205,7 @@
                     class="q-choropleth-legend-bucket {getColorClass(legendData.buckets[0])}"
                     style="fill: {getCustomColor(legendData.buckets[0])}" />
                 </svg>
-                <div class="s-legend-item-label__item__label">
+                <div class="s-legend-item-label__item__label s-font-note--tabularnums">
                   = {getFormattedValueForBuckets(formattingOptions, legendData.buckets[0].from)}
                 </div>
               </div>

--- a/views/Hexagon/Hexagon.svelte
+++ b/views/Hexagon/Hexagon.svelte
@@ -20,7 +20,8 @@
     getPolygonPoints(x, y, width, growFactor),
     1
   );
-  const fontNoteClass = (cssModifier === "narrow" ? "s-font-note-s" : "s-font-note");
+  const fontNoteClass =
+    cssModifier === "narrow" ? "s-font-note-s" : "s-font-note";
 
   /**
    * grow factor = 1 would mean, that hexagons are sticked together
@@ -31,9 +32,9 @@
    */
   function getGrowFactor(hasAnnotation, cssModifier, type) {
     if (hasAnnotation) {
-      return (cssModifier === "narrow" ? 0.935 : 0.96);
+      return cssModifier === "narrow" ? 0.935 : 0.96;
     } else {
-      return (type === 'fill' ? 0.98 : 0.97);
+      return type === "fill" ? 0.98 : 0.97;
     }
   }
 
@@ -77,7 +78,7 @@
     fill={color.customColor && color.customColor.length > 0 ? color.customColor : 'currentColor'}
     stroke={undefined}
     stroke-width={undefined} />
-  <g class={fontNoteClass}>
+  <g class="{fontNoteClass} s-font-note--tabularnums">
     {#if valuesOnMap}
       <text
         x={x + width / 2}
@@ -121,7 +122,7 @@
     fill="#fff"
     stroke="currentColor"
     stroke-width="0.4" />
-  <g class={fontNoteClass}>
+  <g class="{fontNoteClass} s-font-note--tabularnums">
     {#if valuesOnMap}
       <text
         x={x + width / 2}

--- a/views/MethodBox.svelte
+++ b/views/MethodBox.svelte
@@ -20,7 +20,7 @@
             q-choropleth-methods-circle-static s-legend-item-label__item__icon
             s-legend-item-label__item__icon--default"
             style="color: {bucket.color.customColor !== undefined ? bucket.color.customColor : ''};" />
-          <div class="s-legend-item-label__item__label">
+          <div class="s-legend-item-label__item__label s-font-note--tabularnums">
             {#if index === 0 && legendData.hasSingleValueBucket}
               {getFormattedValueForBuckets(formattingOptions, bucket.from)} (nur
               ein Datenpunkt)
@@ -43,7 +43,7 @@
   </div>
   <div class="q-choropleth-methods-container hidden s-font-note-s">
     <div class="q-choropleth-methods-legend">
-      <table class="q-choropleth-methods-legend-table">
+      <table class="q-choropleth-methods-legend-table s-font-note--tabularnums">
         {#each legendData.buckets as bucket, index}
           <tr>
             <td>
@@ -64,7 +64,7 @@
               <td>
                 {getFormattedValueForBuckets(formattingOptions, bucket.from)}
               </td>
-              <td>-</td>
+              <td>–</td>
               <td>
                 {getFormattedValueForBuckets(formattingOptions, bucket.to)}
               </td>


### PR DESCRIPTION
Depends on https://github.com/nzzdev/sophie-font/pull/12

Tabular numerals have been (hopefully correctly) set on
- numeric legend
- hexagon values
- values in method box