### PR TITLE
Release v1.7.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "q-choropleth",
-  "version": "1.7.6",
+  "version": "1.7.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "q-choropleth",
-  "version": "1.7.6",
+  "version": "1.7.7",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/views/Geographic/Feature.svelte
+++ b/views/Geographic/Feature.svelte
@@ -1,19 +1,31 @@
 <script>
   export let color;
+  export let value;
   export let path;
   export let hasAnnotation = false;
   export let strokeWidth;
 </script>
 
 <g class={color.colorClass}>
-  <path
-    fill={color.customColor && color.customColor.length > 0
-      ? color.customColor
-      : "currentColor"}
-    stroke="#fff"
-    stroke-width={strokeWidth}
-    d={path}
-  />
+  {#if value !== null && value !== undefined}
+    <path
+      fill={color.customColor && color.customColor.length > 0
+        ? color.customColor
+        : "currentColor"}
+      stroke="#fff"
+      stroke-width={strokeWidth}
+      d={path}
+    />
+  {:else}
+    <path
+      fill="#fff"
+      stroke={color.customColor && color.customColor.length > 0
+        ? color.customColor
+        : "currentColor"}
+      stroke-width={strokeWidth}
+      d={path}
+    />
+  {/if}
   {#if hasAnnotation}
     <path
       class="s-color-gray-9"

--- a/views/Geographic/GeographicMap.svelte
+++ b/views/Geographic/GeographicMap.svelte
@@ -80,6 +80,7 @@
             dataMapping.get(feature.properties[entityType]),
             legendData
           )}
+          value={dataMapping.get(feature.properties[entityType])}
           path={roundCoordinatesInPath(geoParameters.path(feature), 1)}
           {strokeWidth}
         />
@@ -123,6 +124,7 @@
                 dataMapping.get(feature.properties[entityType]),
                 legendData
               )}
+              value={dataMapping.get(feature.properties[entityType])}
               path={roundCoordinatesInPath(geoParameters.path(feature), 1)}
               hasAnnotation={true}
               {strokeWidth}


### PR DESCRIPTION
This release fixes the design of geographic features with empty values. See [this Basecamp-Todo](https://3.basecamp.com/3500782/buckets/1333707/todos/4388444252) for more details.

Can be tested on staging: https://q.st-staging.nzz.ch/item/choropleth-4