### PR TITLE
Add new version of ch municipalities geographic

### DIFF
--- a/basemaps/prepare-basemaps/config/basemaps.js
+++ b/basemaps/prepare-basemaps/config/basemaps.js
@@ -154,6 +154,23 @@ module.exports = [
     title: "Schweiz » Gemeinden",
     versions: [
       {
+        validFrom: "2022-01-01T00:00:00.000Z",
+        data: {
+          source: {
+            url: "https://www.bfs.admin.ch/bfs/de/home/dienstleistungen/geostat/geodaten-bundesstatistik/administrative-grenzen/generalisierte-gemeindegrenzen.html",
+            label: "© BfS, ThemaKart",
+          },
+          config: {
+            defaultEntityType: "id",
+            entityTypes: {
+              id: "BfS Nummer",
+            },
+            projection: "mercator",
+          },
+          entities: require("./basemaps/ch-municipalities-geographic.js"),
+        },
+      },
+      {
         validFrom: "2021-07-01T00:00:00.000Z",
         data: {
           source: {

--- a/basemaps/prepare-basemaps/config/basemaps/ch-municipalities-geographic.js
+++ b/basemaps/prepare-basemaps/config/basemaps/ch-municipalities-geographic.js
@@ -2,6 +2,16 @@ const unzipper = require("unzipper");
 const fetch = require("node-fetch");
 
 const config = {
+  "2022-01-01T00:00:00.000Z": {
+    dataUrl: "https://www.bfs.admin.ch/bfsstatic/dam/assets/21224783/master",
+    featuresPath: "./ggg_2022_LV95/shp/k4g22.shp",
+    waterPath: "./ggg_2022_LV95/shp/k4s22.shp",
+    featuresPropertyMapping: {
+      id: "GMDNR",
+      name: "GMDNAME",
+    },
+    rewriteProperties: {},
+  },
   "2021-07-01T00:00:00.000Z": {
     dataUrl: "https://www.bfs.admin.ch/bfsstatic/dam/assets/17964056/master",
     featuresPath: "./ggg_2021-LV95/shp/k4g21_01072021.shp",


### PR DESCRIPTION
- Add new version ([31.01.2022](https://www.bfs.admin.ch/bfs/de/home/dienstleistungen/geostat/geodaten-bundesstatistik/administrative-grenzen/generalisierte-gemeindegrenzen.assetdetail.21224783.html)) of ch municipalities geographic.

### Todo
- https://3.basecamp.com/3500782/buckets/21199778/todos/4449601639

### Example
- [New Version (31.01.2022)](https://q.st-staging.nzz.ch/item/ecf1db20c4ca6dcf6e79099067035352) vs. [old version (01.01.2021)](https://q.st-staging.nzz.ch/item/e9046b127bd99afc9cd208b94d6b0c42)