### PR TITLE
feat-hide-small-states

### DIFF
--- a/resources/schema.json
+++ b/resources/schema.json
@@ -681,6 +681,28 @@
               }
             ]
           }
+        },
+        "hideMicroStates": {
+          "title": "Mikrostaaten ausblenden",
+          "type": "boolean",
+          "default": true,
+          "Q:options": {
+            "availabilityChecks": [
+              {
+                "type": "UserHasRole",
+                "config": {
+                  "role": "expert-choropleth"
+                }
+              },
+              {
+                "type": "ToolEndpoint",
+                "config": {
+                  "endpoint": "option-availability/hideMicroStates",
+                  "fields": ["baseMap"]
+                }
+              }
+            ]
+          }
         }
       }
     }

--- a/routes/option-availability.js
+++ b/routes/option-availability.js
@@ -64,6 +64,12 @@ module.exports = {
       };
     }
 
+    if (optionName === "hideMicroStates") {
+      return {
+        available: item.baseMap.includes("europe-countries-geographic"),
+      };
+    }
+
     return Boom.badRequest();
   },
 };

--- a/routes/rendering-info/web.js
+++ b/routes/rendering-info/web.js
@@ -119,6 +119,7 @@ module.exports = {
 
       context.item = item;
       context.showBubbleMap = item.baseMap.includes("world-countries-geographic") && !item.options.hideBubbleMap;
+      context.showMicroStates = item.baseMap.includes("europe-countries-geographic") && !item.options.hideMicroStates;
 
       const exactPixelWidth = getExactPixelWidth(
         request.payload.toolRuntimeConfig

--- a/views/Choropleth.svelte
+++ b/views/Choropleth.svelte
@@ -18,6 +18,7 @@
   export let formattingOptions;
   export let isStatic;
   export let showBubbleMap = false;
+  export let showMicroStates = false;
 
   const dataMapping = new Map(item.data);
   const maxHeight = 550;
@@ -73,6 +74,7 @@
           {contentWidth}
           {cssModifier}
           {maxHeight}
+          {showMicroStates}
         />
         {#if baseMap.mobile && baseMap.mobile.length > 0}
           {#each baseMap.mobile as mobileBaseMap}
@@ -87,6 +89,7 @@
               {contentWidth}
               {cssModifier}
               {maxHeight}
+              {showMicroStates}
             />
           {/each}
         {/if}
@@ -107,6 +110,7 @@
                   contentWidth={miniMap.width}
                   {cssModifier}
                   {maxHeight}
+                  {showMicroStates}
                 />
               </div>
               {#if miniMap.title}

--- a/views/Choropleth.svelte
+++ b/views/Choropleth.svelte
@@ -129,6 +129,11 @@
     {#if baseMap.data.source}
       <Attribution source={baseMap.data.source} {isStatic} />
     {/if}
+    {#if showMicroStates}
+      <div class="choropleth-geographic__micro-states s-font-note-s s-font-note-s--light">
+        Die Kreise repräsentieren die darunterliegenden Mikrostaaten und sollen diese erkennbar machen.
+      </div>
+    {/if}
     {#if legendData.type === "numerical"}
       <MethodBox
         {legendData}
@@ -161,5 +166,9 @@
 
   .choropleth-geographic-minimap__title {
     text-align: center;
+  }
+
+  .choropleth-geographic__micro-states {
+    margin-bottom: 8px;
   }
 </style>

--- a/views/Choropleth.svelte
+++ b/views/Choropleth.svelte
@@ -131,7 +131,7 @@
     {/if}
     {#if showMicroStates}
       <div class="choropleth-geographic__micro-states s-font-note-s s-font-note-s--light">
-        Die Kreise repräsentieren die darunterliegenden Mikrostaaten und sollen diese erkennbar machen.
+        Die Kreise repräsentieren die darunterliegenden Kleinstaaten und sollen diese erkennbar machen.
       </div>
     {/if}
     {#if legendData.type === "numerical"}

--- a/views/Geographic/GeographicMap.svelte
+++ b/views/Geographic/GeographicMap.svelte
@@ -79,16 +79,42 @@
 
   function getFeaturesWithoutAnnotation(features, annotations, entityType) {
     if (!features) return [];
-    return features.filter((f) => {
-      return !regionHasAnnotation(annotations, f.properties[entityType]) && f.properties.showAsBubble !== "true"; // don't render features which'll be rendered as bubbles
+
+    let retVal = features;
+
+    // all features without annotations
+    retVal = retVal.filter((f) => {
+      return !regionHasAnnotation(annotations, f.properties[entityType]);
     });
+
+    // don't render features which'll be rendered as bubbles
+    if (showMicroStates === true) {
+      retVal = retVal.filter((f) => {
+        return f.properties.showAsBubble !== "true";
+      });
+    }
+
+    return retVal;
   }
 
   function getFeaturesWithAnnotation(features, annotations, entityType) {
     if (!features) return [];
-    return features.filter((f) => {
-      return regionHasAnnotation(annotations, f.properties[entityType]) && f.properties.showAsBubble !== "true"; // don't render features which'll be rendered as bubbles
+
+    let retVal = features;
+
+    // all features without annotations
+    retVal = retVal.filter((f) => {
+      return regionHasAnnotation(annotations, f.properties[entityType]);
     });
+
+    // don't render features which'll be rendered as bubbles
+    if (showMicroStates === true) {
+      retVal = retVal.filter((f) => {
+        return f.properties.showAsBubble !== "true";
+      });
+    }
+
+    return retVal;
   }
 
   function getFeaturesShownAsBubble(features) {

--- a/views/Geographic/GeographicMap.svelte
+++ b/views/Geographic/GeographicMap.svelte
@@ -26,6 +26,7 @@
   export let entityType;
   export let legendData;
   export let maxHeight = 550;
+  export let showMicroStates = false;
   
   const annotationStartPosition = annotationRadius * 2;
   const annotationSpace = 2 * (annotationRadius + annotationStartPosition + 1); // times two, because annotations can be on both sides (top/bottom or left/right)
@@ -236,20 +237,22 @@
           {/if}
         </g>
       {/if}
-      <g>
-        {#each featuresShownAsBubble as feature}
-          <Bubble
-            centroid={feature.properties.centroidPlanar}
-            color={getColor(
-              dataMapping.get(feature.properties[entityType]),
-              legendData
-            )}
-            defaultRadius={defaultBubbleRadius}
-            hasAnnotation={regionHasAnnotation(annotations, feature.properties[entityType])}
-            hasValue={dataMapping.get(feature.properties[entityType]) ? true : false}
-          />
-        {/each}
-      </g>
+      {#if showMicroStates}
+        <g>
+          {#each featuresShownAsBubble as feature}
+            <Bubble
+              centroid={feature.properties.centroidPlanar}
+              color={getColor(
+                dataMapping.get(feature.properties[entityType]),
+                legendData
+              )}
+              defaultRadius={defaultBubbleRadius}
+              hasAnnotation={regionHasAnnotation(annotations, feature.properties[entityType])}
+              hasValue={dataMapping.get(feature.properties[entityType]) ? true : false}
+            />
+          {/each}
+        </g>
+      {/if}
     {/if}
   </svg>
 </ResponsiveSvg>


### PR DESCRIPTION
- add option for hiding micro states
- add explanation for the bubbles that represent the micro states above footer